### PR TITLE
fix/set-attempts-to-second-pokemon

### DIFF
--- a/src/pages/BattlePage.tsx
+++ b/src/pages/BattlePage.tsx
@@ -87,7 +87,6 @@ function BattlePage() {
     setPlayerDead(dead);
     if (dead) {
       setShowResultModal(true);
-      setCatchAttempts(0);
       setDeadPokemons((prev) => [...prev, fightingPokemon.id]);
     }
   }, [myHp, fightingPokemon.id]);
@@ -491,6 +490,7 @@ function BattlePage() {
         }}
         caughtPokemon={isCaught ? rivalPokemon : undefined}
         onSwitchPokemon={(pokemon) => {
+          setCatchAttempts(0);
           setShowResultModal(false);
           setFightingPokemon(pokemon);
           setMyHp(pokemon.hp ?? 100);


### PR DESCRIPTION
fix: set catch attempts to 0 when new pokemon is selected to battle.