### PR TITLE
feature/adjust-select-poke-to-pagination

### DIFF
--- a/src/components/ui/NavBar/PokemonNavbar.tsx
+++ b/src/components/ui/NavBar/PokemonNavbar.tsx
@@ -14,8 +14,22 @@ import type { PokemonModal } from "@/lib/types";
 import { transformToPokemonModal } from "@/lib/utils/mapMyPokemons";
 import { useUserPokemons } from "@/lib/hooks/useUserPokemons";
 
-function PokemonNavbar({ activeItem, onChange }: PokemonNavbarProps) {
-  const { data: userPokemonsData } = useUserPokemons();
+function PokemonNavbar({
+  activeItem,
+  onChange,
+  sortBy = "id",
+  order = "asc",
+  search = "",
+  page = 1,
+  limit = 10,
+}: PokemonNavbarProps) {
+  const { data: userPokemonsData } = useUserPokemons(
+    page,
+    limit,
+    search,
+    sortBy,
+    order
+  );
   const pokemonsData: PokemonModal[] =
     userPokemonsData?.data.map(transformToPokemonModal) || [];
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -89,6 +89,11 @@ export interface PokemonModal {
 export interface PokemonNavbarProps {
   activeItem: Tab;
   onChange: (value: Tab) => void;
+  page?: number ;
+  limit?: number;
+  sortBy?: string | "id";
+  order?: 'asc' | 'desc';
+  search?: string;
 }
 
 export const Tab = {

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -119,6 +119,11 @@ function HomePage() {
           setActiveTab(newTab);
           setPage(1);
         }}
+        page={page}
+        limit={limit}
+        sortBy={sortBy}
+        order={order}
+        search={searchTerm}
       />
 
       <main className="max-w-1440 mx-auto px-10">


### PR DESCRIPTION
feat: add props to navbar in order to present the pokemons that are not include in the default limit (10).